### PR TITLE
make SDK.jl async

### DIFF
--- a/src/navability/entities/NavAbilityClient.jl
+++ b/src/navability/entities/NavAbilityClient.jl
@@ -24,9 +24,11 @@ end
 function NavAbilityHttpsClient(apiUrl::String="https://api.d1.navability.io")::NavAbilityClient
     dianaClient = GraphQLClient(apiUrl)
     function query(options::QueryOptions)
+        # TODO does Diana or Deloittes return async?
         dianaClient.Query(options.query, operationName=options.name, vars=options.variables)
     end
     function mutate(options::MutationOptions)
+        # TODO does Diana or Deloittes return async?
         dianaClient.Query(options.mutation, operationName=options.name, vars=options.variables)
     end
     return NavAbilityClient(query, mutate)

--- a/src/navability/services/Factor.jl
+++ b/src/navability/services/Factor.jl
@@ -24,7 +24,7 @@ function addFactor(navAbilityClient::NavAbilityClient, client::Client, factor::F
     return @async addPackedFactor(navAbilityClient, client, factor)
 end
 
-function _getFactor(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
+function _getFactorEvent(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_factor",
         """
@@ -55,9 +55,9 @@ function _getFactor(navAbilityClient::NavAbilityClient, client::Client, label::S
     return factors[1]
 end
 
-getFactor(navAbilityClient::NavAbilityClient, client::Client, label::String) = @async _getFactor(navAbilityClient, client, label)
+getFactor(navAbilityClient::NavAbilityClient, client::Client, label::String) = @async _getFactorEvent(navAbilityClient, client, label)
 
-function _getFactors(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
+function getFactorsEvent(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_factors",
         """
@@ -87,7 +87,7 @@ function _getFactors(navAbilityClient::NavAbilityClient, client::Client; detail:
     return get(sessions[1],"factors",[])
 end
 
-getFactors( navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON) = @async _getFactors(navAbilityClient, client; detail )
+getFactors( navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON) = @async getFactorsEvent(navAbilityClient, client; detail )
 
 function listFactors(navAbilityClient::NavAbilityClient, client::Client)
     @async begin

--- a/src/navability/services/Factor.jl
+++ b/src/navability/services/Factor.jl
@@ -20,8 +20,8 @@ function addPackedFactor(navAbilityClient::NavAbilityClient, client::Client, fac
     return addFactor
 end
 
-function addFactor(navAbilityClient::NavAbilityClient, client::Client, factor::Factor)::String
-    return addPackedFactor(navAbilityClient, client, factor)
+function addFactor(navAbilityClient::NavAbilityClient, client::Client, factor::Factor)
+    return @async addPackedFactor(navAbilityClient, client, factor)
 end
 
 function getFactor(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}

--- a/src/navability/services/Factor.jl
+++ b/src/navability/services/Factor.jl
@@ -91,7 +91,7 @@ getFactors( navAbilityClient::NavAbilityClient, client::Client; detail::QueryDet
 
 function listFactors(navAbilityClient::NavAbilityClient, client::Client)
     @async begin
-        factors = fetch(getFactors(navAbilityClient,client))
+        factors = getFactors(navAbilityClient,client) |> fetch
         map(v -> v["label"], factors)
     end
 end

--- a/src/navability/services/Factor.jl
+++ b/src/navability/services/Factor.jl
@@ -24,7 +24,7 @@ function addFactor(navAbilityClient::NavAbilityClient, client::Client, factor::F
     return @async addPackedFactor(navAbilityClient, client, factor)
 end
 
-function getFactor(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
+function _getFactor(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_factor",
         """
@@ -55,7 +55,9 @@ function getFactor(navAbilityClient::NavAbilityClient, client::Client, label::St
     return factors[1]
 end
 
-function getFactors(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
+getFactor(navAbilityClient::NavAbilityClient, client::Client, label::String) = @async _getFactor(navAbilityClient, client, label)
+
+function _getFactors(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_factors",
         """
@@ -85,11 +87,15 @@ function getFactors(navAbilityClient::NavAbilityClient, client::Client; detail::
     return get(sessions[1],"factors",[])
 end
 
-function listFactors(navAbilityClient::NavAbilityClient, client::Client)::Vector{String}
-    factors = getFactors(navAbilityClient,client)
-    return map(v -> v["label"], factors)
+getFactors( navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON) = @async _getFactors(navAbilityClient, client; detail )
+
+function listFactors(navAbilityClient::NavAbilityClient, client::Client)
+    @async begin
+        factors = fetch(getFactors(navAbilityClient,client))
+        map(v -> v["label"], factors)
+    end
 end
 
-function lsf(navAbilityClient::NavAbilityClient, client::Client)::Vector{String}
+function lsf(navAbilityClient::NavAbilityClient, client::Client)
     return listFactors(navAbilityClient,client)
 end

--- a/src/navability/services/Solve.jl
+++ b/src/navability/services/Solve.jl
@@ -1,5 +1,5 @@
 
-function solveSession(navAbilityClient::NavAbilityClient, client::Client)::String
+function solveSessionEvent(navAbilityClient::NavAbilityClient, client::Client)::String
     response = navAbilityClient.mutate(MutationOptions(
         "solveSession",
         MUTATION_SOLVESESSION,
@@ -17,7 +17,10 @@ function solveSession(navAbilityClient::NavAbilityClient, client::Client)::Strin
     return solveSession
 end
 
-function solveFederated(navAbilityClient::NavAbilityClient, scope::Scope)::String
+solveSession(w...;kw...) = @async solveSessionEvent(w...; kw...)
+
+
+function solveFederatedEvent(navAbilityClient::NavAbilityClient, scope::Scope)::String
     response = navAbilityClient.mutate(MutationOptions(
         "solveFederated",
         MUTATION_SOLVEFEDERATED,
@@ -30,3 +33,7 @@ function solveFederated(navAbilityClient::NavAbilityClient, scope::Scope)::Strin
     solveSession = get(data,"solveSession","Error")
     return solveSession
 end
+
+solveFederated(w...;kw...) = @async solveFederatedEvent(w...;kw...)
+
+#

--- a/src/navability/services/Solve.jl
+++ b/src/navability/services/Solve.jl
@@ -1,5 +1,5 @@
 
-function solveSessionEvent(navAbilityClient::NavAbilityClient, client::Client)::String
+function _solveSession(navAbilityClient::NavAbilityClient, client::Client)::String
     response = navAbilityClient.mutate(MutationOptions(
         "solveSession",
         MUTATION_SOLVESESSION,
@@ -9,7 +9,7 @@ function solveSessionEvent(navAbilityClient::NavAbilityClient, client::Client)::
     ))
     rootData = JSON.parse(response.Data)
     if haskey(rootData, "errors")
-        throw("Error: $(data["errors"])")
+        throw("Error: $(rootData["errors"])")
     end
     data = get(rootData,"data",nothing)
     if data === nothing return "Error" end
@@ -17,10 +17,10 @@ function solveSessionEvent(navAbilityClient::NavAbilityClient, client::Client)::
     return solveSession
 end
 
-solveSession(w...;kw...) = @async solveSessionEvent(w...; kw...)
+solveSession(navAbilityClient::NavAbilityClient, client::Client) = @async _solveSession(navAbilityClient, client)
 
 
-function solveFederatedEvent(navAbilityClient::NavAbilityClient, scope::Scope)::String
+function _solveFederated(navAbilityClient::NavAbilityClient, scope::Scope)::String
     response = navAbilityClient.mutate(MutationOptions(
         "solveFederated",
         MUTATION_SOLVEFEDERATED,
@@ -28,12 +28,16 @@ function solveFederatedEvent(navAbilityClient::NavAbilityClient, scope::Scope)::
             "scope" => scope,
         )
     ))
+    rootData = JSON.parse(response.Data)
+    if haskey(rootData, "errors")
+        throw("Error: $(rootData["errors"])")
+    end
     data = get(rootData,"data",nothing)
     if data === nothing return "Error" end
     solveSession = get(data,"solveSession","Error")
     return solveSession
 end
 
-solveFederated(w...;kw...) = @async solveFederatedEvent(w...;kw...)
+solveFederated(navAbilityClient::NavAbilityClient, scope::Scope) = @async _solveFederated(navAbilityClient, scope)
 
 #

--- a/src/navability/services/Solve.jl
+++ b/src/navability/services/Solve.jl
@@ -1,5 +1,5 @@
 
-function _solveSession(navAbilityClient::NavAbilityClient, client::Client)::String
+function solveSessionEvent(navAbilityClient::NavAbilityClient, client::Client)::String
     response = navAbilityClient.mutate(MutationOptions(
         "solveSession",
         MUTATION_SOLVESESSION,
@@ -17,10 +17,10 @@ function _solveSession(navAbilityClient::NavAbilityClient, client::Client)::Stri
     return solveSession
 end
 
-solveSession(navAbilityClient::NavAbilityClient, client::Client) = @async _solveSession(navAbilityClient, client)
+solveSession(navAbilityClient::NavAbilityClient, client::Client) = @async solveSessionEvent(navAbilityClient, client)
 
 
-function _solveFederated(navAbilityClient::NavAbilityClient, scope::Scope)::String
+function solveFederatedEvent(navAbilityClient::NavAbilityClient, scope::Scope)::String
     response = navAbilityClient.mutate(MutationOptions(
         "solveFederated",
         MUTATION_SOLVEFEDERATED,
@@ -38,6 +38,6 @@ function _solveFederated(navAbilityClient::NavAbilityClient, scope::Scope)::Stri
     return solveSession
 end
 
-solveFederated(navAbilityClient::NavAbilityClient, scope::Scope) = @async _solveFederated(navAbilityClient, scope)
+solveFederated(navAbilityClient::NavAbilityClient, scope::Scope) = @async solveFederatedEvent(navAbilityClient, scope)
 
 #

--- a/src/navability/services/Status.jl
+++ b/src/navability/services/Status.jl
@@ -7,7 +7,7 @@ Args:
     navAbilityClient (NavAbilityClient): The NavAbility client.
     id (String): The ID of the request that you want the statuses on.
 """
-function _getStatusMessages(navAbilityClient::NavAbilityClient, id::String)
+function getStatusMessagesEvent(navAbilityClient::NavAbilityClient, id::String)
     response = navAbilityClient.mutate(MutationOptions(
         "sdk_ls_statusmessages",
         GQL_GETSTATUSMESSAGES,
@@ -26,7 +26,7 @@ function _getStatusMessages(navAbilityClient::NavAbilityClient, id::String)
     return statusMessages
 end
 
-getStatusMessages(navAbilityClient::NavAbilityClient, id::String) = @async _getStatusMessages(navAbilityClient, id)
+getStatusMessages(navAbilityClient::NavAbilityClient, id::String) = @async getStatusMessagesEvent(navAbilityClient, id)
 
 """
 $(SIGNATURES)
@@ -36,7 +36,7 @@ Args:
     navAbilityClient (NavAbilityClient): The NavAbility client.
     id (String): The ID of the request that you want the latest status on.
 """
-function _getStatusLatest(navAbilityClient::NavAbilityClient, id::String)
+function getStatusLatestEvent(navAbilityClient::NavAbilityClient, id::String)
     response = navAbilityClient.mutate(MutationOptions(
         "sdk_get_statuslatest",
         GQL_GETSTATUSLATEST,
@@ -56,7 +56,7 @@ function _getStatusLatest(navAbilityClient::NavAbilityClient, id::String)
     return statusMessage
 end
 
-getStatusLatest(navAbilityClient::NavAbilityClient, id::String) = @async _getStatusLatest(navAbilityClient, id)
+getStatusLatest(navAbilityClient::NavAbilityClient, id::String) = @async getStatusLatestEvent(navAbilityClient, id)
 
 """
 $(SIGNATURES)

--- a/src/navability/services/Status.jl
+++ b/src/navability/services/Status.jl
@@ -7,7 +7,7 @@ Args:
     navAbilityClient (NavAbilityClient): The NavAbility client.
     id (String): The ID of the request that you want the statuses on.
 """
-function getStatusMessages(navAbilityClient::NavAbilityClient, id::String)
+function _getStatusMessages(navAbilityClient::NavAbilityClient, id::String)
     response = navAbilityClient.mutate(MutationOptions(
         "sdk_ls_statusmessages",
         GQL_GETSTATUSMESSAGES,
@@ -26,6 +26,8 @@ function getStatusMessages(navAbilityClient::NavAbilityClient, id::String)
     return statusMessages
 end
 
+getStatusMessages(navAbilityClient::NavAbilityClient, id::String) = @async _getStatusMessages(navAbilityClient, id)
+
 """
 $(SIGNATURES)
 Get the latest status message for a request.
@@ -34,7 +36,7 @@ Args:
     navAbilityClient (NavAbilityClient): The NavAbility client.
     id (String): The ID of the request that you want the latest status on.
 """
-function getStatusLatest(navAbilityClient::NavAbilityClient, id::String)
+function _getStatusLatest(navAbilityClient::NavAbilityClient, id::String)
     response = navAbilityClient.mutate(MutationOptions(
         "sdk_get_statuslatest",
         GQL_GETSTATUSLATEST,
@@ -54,6 +56,8 @@ function getStatusLatest(navAbilityClient::NavAbilityClient, id::String)
     return statusMessage
 end
 
+getStatusLatest(navAbilityClient::NavAbilityClient, id::String) = @async _getStatusLatest(navAbilityClient, id)
+
 """
 $(SIGNATURES)
 Helper function to get a dictionary of all latest statues for a list of results.
@@ -63,5 +67,7 @@ Args:
     ids (Vector{String}): A list of the IDS that you want statuses on.
 """
 function getStatusesLatest(navAbilityClient::NavAbilityClient, ids::Vector{String})
-    return Dict(r=>getStatusLatest(navAbilityClient, r) for r in ids)
+    @async begin
+        return Dict(r=>fetch(getStatusLatest(navAbilityClient, r)) for r in ids)
+    end
 end

--- a/src/navability/services/Utils.jl
+++ b/src/navability/services/Utils.jl
@@ -21,7 +21,7 @@ function waitForCompletion(
     wait_time = maxSeconds
     tasksComplete = false
     while !tasksComplete
-        statuses = values(getStatusesLatest(navAbilityClient, requestIds))
+        statuses = values(fetch( getStatusesLatest(navAbilityClient, requestIds) ))
         tasksComplete = all(s["state"] in expectedStatuses for s in statuses)
         if tasksComplete
             return

--- a/src/navability/services/Utils.jl
+++ b/src/navability/services/Utils.jl
@@ -10,10 +10,10 @@ Args:
 """
 function waitForCompletion(
     navAbilityClient::NavAbilityClient,
-    requestIds::Vector{String};
-    maxSeconds::Int = 60,
-    expectedStatuses::Vector{String} = Nothing,
-    exceptionMessage::String = "Requests did not complete in time")
+    requestIds::AbstractVector{<:AbstractString};
+    maxSeconds::Integer = 60,
+    expectedStatuses::AbstractVector{<:AbstractString} = Nothing,
+    exceptionMessage::AbstractString = "Requests did not complete in time")
 #
     if expectedStatuses == Nothing
         expectedStatuses = ["Complete", "Failed"]
@@ -31,4 +31,14 @@ function waitForCompletion(
             wait_time <= 0 && throw(error(exceptionMessage))
         end
     end
+end
+
+# Dispatch for vector of Tasks
+function waitForCompletion(
+    navAbilityClient::NavAbilityClient,
+    requestIds::AbstractVector{<:Task};
+    kw...)
+    #
+    rids = fetch.(requestIds) .|> string
+    waitForCompletion(navAbilityClient, rids; kw...)
 end

--- a/src/navability/services/Variable.jl
+++ b/src/navability/services/Variable.jl
@@ -24,7 +24,7 @@ function addVariable(navAbilityClient::NavAbilityClient, client::Client, variabl
     return @async addPackedVariable(navAbilityClient, client, variable)
 end
 
-function getVariable(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
+function _getVariable(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_variable",
         """
@@ -55,7 +55,9 @@ function getVariable(navAbilityClient::NavAbilityClient, client::Client, label::
     return variables[1]
 end
 
-function getVariables(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
+getVariable(navAbilityClient::NavAbilityClient, client::Client, label::String) = @async _getVariable(navAbilityClient, client, label)
+
+function _getVariables(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_variables",
         """
@@ -85,11 +87,15 @@ function getVariables(navAbilityClient::NavAbilityClient, client::Client; detail
     return get(sessions[1],"variables",[])
 end
 
-function listVariables(navAbilityClient::NavAbilityClient, client::Client)::Vector{String}
-    variables = getVariables(navAbilityClient,client)
-    return map(v -> v["label"], variables)
+getVariables(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON) = @async _getVariables(navAbilityClient, client; detail)
+
+function listVariables(navAbilityClient::NavAbilityClient, client::Client)
+    @async begin
+        variables = getVariables(navAbilityClient,client)
+        return map(v -> v["label"], variables)
+    end
 end
 
-function ls(navAbilityClient::NavAbilityClient, client::Client)::Vector{String}
+function ls(navAbilityClient::NavAbilityClient, client::Client)
     return listVariables(navAbilityClient,client)
 end

--- a/src/navability/services/Variable.jl
+++ b/src/navability/services/Variable.jl
@@ -91,8 +91,8 @@ getVariables(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDe
 
 function listVariables(navAbilityClient::NavAbilityClient, client::Client)
     @async begin
-        variables = getVariables(navAbilityClient,client)
-        return map(v -> v["label"], variables)
+        variables = getVariables(navAbilityClient,client) |> fetch
+        map(v -> v["label"], variables)
     end
 end
 

--- a/src/navability/services/Variable.jl
+++ b/src/navability/services/Variable.jl
@@ -24,7 +24,7 @@ function addVariable(navAbilityClient::NavAbilityClient, client::Client, variabl
     return @async addPackedVariable(navAbilityClient, client, variable)
 end
 
-function _getVariable(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
+function getVariableEvent(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_variable",
         """
@@ -55,9 +55,9 @@ function _getVariable(navAbilityClient::NavAbilityClient, client::Client, label:
     return variables[1]
 end
 
-getVariable(navAbilityClient::NavAbilityClient, client::Client, label::String) = @async _getVariable(navAbilityClient, client, label)
+getVariable(navAbilityClient::NavAbilityClient, client::Client, label::String) = @async getVariableEvent(navAbilityClient, client, label)
 
-function _getVariables(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
+function getVariablesEvent(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON)::Vector{Dict{String,Any}}
     response = navAbilityClient.query(QueryOptions(
         "sdk_get_variables",
         """
@@ -87,7 +87,7 @@ function _getVariables(navAbilityClient::NavAbilityClient, client::Client; detai
     return get(sessions[1],"variables",[])
 end
 
-getVariables(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON) = @async _getVariables(navAbilityClient, client; detail)
+getVariables(navAbilityClient::NavAbilityClient, client::Client; detail::QueryDetail = SKELETON) = @async getVariablesEvent(navAbilityClient, client; detail)
 
 function listVariables(navAbilityClient::NavAbilityClient, client::Client)
     @async begin

--- a/src/navability/services/Variable.jl
+++ b/src/navability/services/Variable.jl
@@ -20,8 +20,8 @@ function addPackedVariable(navAbilityClient::NavAbilityClient, client::Client, v
     return addVariable
 end
 
-function addVariable(navAbilityClient::NavAbilityClient, client::Client, variable::Variable)::String
-    return addPackedVariable(navAbilityClient, client, variable)
+function addVariable(navAbilityClient::NavAbilityClient, client::Client, variable::Variable)
+    return @async addPackedVariable(navAbilityClient, client, variable)
 end
 
 function getVariable(navAbilityClient::NavAbilityClient, client::Client, label::String)::Dict{String,Any}

--- a/test/integration/fixtures.jl
+++ b/test/integration/fixtures.jl
@@ -50,24 +50,24 @@ function exampleGraph1D(client, context; doSolve=true)
     ]
     # Variables
     @info "[Fixture] Adding variables, waiting for completion"
-    resultIds = String[]
+    resultIds = Task[]
     for v in variables
       push!(resultIds, addVariable(client, context, v))
     end
-    waitForCompletion(client, string.(resultIds); expectedStatuses=["Complete"])
+    waitForCompletion(client, resultIds; expectedStatuses=["Complete"])
   
     # Add the factors
     @info "[Fixture] Adding factors, waiting for completion"
-    resultIds = String[]
+    resultIds = Task[]
     for f in factors
       push!(resultIds, addFactor(client, context, f))
     end
-    waitForCompletion(client, string.(resultIds); expectedStatuses=["Complete"])
+    waitForCompletion(client, resultIds; expectedStatuses=["Complete"])
     
     if doSolve
       @info "[Fixture] solving, waiting for completion"
       resultId = solveSession(client, context)
-      waitForCompletion(client, String[resultIds;]; expectedStatuses=["Complete"])
+      waitForCompletion(client, Task[resultIds;]; expectedStatuses=["Complete"])
     end
 
     # and done

--- a/test/integration/testFactor.jl
+++ b/test/integration/testFactor.jl
@@ -1,6 +1,6 @@
 
 function testAddFactor(client, context, factorLabels, factorTypes, factorVariables, factorData)
-    resultIds = String[]
+    resultIds = Task[]
     for (index, label) in enumerate(factorLabels)
         resultId = addFactor(client,context,Factor(label, factorTypes[index], factorVariables[index], factorData[index]))
         @test resultId != "Error"
@@ -12,12 +12,12 @@ function testAddFactor(client, context, factorLabels, factorTypes, factorVariabl
 end
 
 function testLsf(client, context, factorLabels, factorTypes)
-    @test setdiff(factorLabels, lsf(client, context)) == []
+    @test setdiff(factorLabels, fetch( lsf(client, context) )) == []
 end
 
 function testGetFactor(client, context, factorLabels, factorTypes)
     for i in 1:length(factorLabels)
-        actualFactor = getFactor(client,context,factorLabels[i])
+        actualFactor = fetch( getFactor(client,context,factorLabels[i]) )
         @test actualFactor["label"] == factorLabels[i]
         @test actualFactor["fnctype"] == factorTypes[i]
     end
@@ -27,7 +27,7 @@ function testGetFactors(client, context, factorLabels, factorTypes)
     # Make a quick dictionary of the expected variable Types
     factorIdType = Dict(factorLabels .=> factorTypes)
 
-    factors = getFactors(client, context, detail=FULL)
+    factors = fetch( getFactors(client, context, detail=FULL) )
     for f in factors
         @test f["fnctype"] == factorIdType[f["label"]]
     end

--- a/test/integration/testSolve.jl
+++ b/test/integration/testSolve.jl
@@ -5,13 +5,13 @@ function testSolveSession(client, context, variableLabels)
     resultId = solveSession(client,context)
 
     # Wait for them to be done before proceeding.
-    waitForCompletion(client, [resultId], expectedStatuses=["Complete"])
+    waitForCompletion(client, Task[resultId;], expectedStatuses=["Complete"])
 
     # Get PPE's are there for the connected variables.
     # TODO - complete the factor graph.
     for v in variableLabels # getVariables(client, context, detail=SUMMARY)
         # First solve key (only) is the default result
-        @test getVariable(client, context, v)["ppes"][1]["solveKey"] == "default"
+        @test fetch( getVariable(client, context, v) )["ppes"][1]["solveKey"] == "default"
     end
 end
 

--- a/test/integration/testVariable.jl
+++ b/test/integration/testVariable.jl
@@ -1,6 +1,6 @@
 
 function testAddVariable(client, context, variableLabels, variableTypes, variableTypeStrings)
-    resultIds = String[]
+    resultIds = Task[]
     for (index, label) in enumerate(variableLabels)
         resultId = addVariable(client, context, Variable(label, variableTypes[index]))
         @test resultId != "Error"
@@ -14,12 +14,12 @@ function testAddVariable(client, context, variableLabels, variableTypes, variabl
 end
 
 function testLs(client, context, variableLabels, variableTypes, variableTypeStrings)
-    @test setdiff(variableLabels, ls(client, context)) == []
+    @test length( setdiff(variableLabels, fetch( ls(client, context) )) ) == 0
 end
 
 function testGetVariable(client, context, variableLabels, variableTypes, variableTypeStrings)
     for i in 1:length(variableLabels)
-        actualVariable = getVariable(client,context,variableLabels[i])
+        actualVariable = getVariable(client,context,variableLabels[i]) |> fetch
         @test actualVariable["label"] == variableLabels[i]
         @test actualVariable["variableType"] == variableTypeStrings[i]
     end
@@ -29,7 +29,7 @@ function testGetVariables(client, context, variableLabels, variableTypes, variab
     # Make a quick dictionary of the expected variable Types
     varIdType = Dict(variableLabels .=> variableTypeStrings)
 
-    variables = getVariables(client, context; detail=SUMMARY)
+    variables = getVariables(client, context; detail=SUMMARY) |> fetch
     for v in variables
         @test v["variableType"] == varIdType[v["label"]]
     end


### PR DESCRIPTION
close
- #85 

This PR makes async the calls for all function similar to SDK.py, but the Diana.jl query and mutate internal calls are still blocking -- we can easily add tnose two asyncs here in SDK if Diana.jl is not doing them internally already.  Since query and mutate as lower level calls, they are usually called by user API functions that already include the async layer, so okay for time being until we know more about Diana.jl

~~@jim-hill-r , do you know of any other functions that should be made async?  If not then SDK.jl should be ready for v0.4.0.  Ill do the release and tagging with confirmation on any missing async functions.~~