### PR TITLE
reenable broken test exportSession

### DIFF
--- a/src/NavAbilitySDK.jl
+++ b/src/NavAbilitySDK.jl
@@ -80,7 +80,7 @@ export initVariable
 export solveSession, solveFederated
 export getStatusMessages, getStatusLatest, getStatusesLatest
 export waitForCompletion
-export exportSession
+export exportSession, getExportSessionBlobId
 export GraphVizApp, MapVizApp
 
 

--- a/src/navability/entities/NavAbilityClient.jl
+++ b/src/navability/entities/NavAbilityClient.jl
@@ -43,11 +43,41 @@ function NavAbilityHttpsClient(
 
     function query(options::QueryOptions)
         # NOTE, the query client library used is synchronous, locally converted to async for package consistency
-        @async dianaClient.Query(options.query, operationName=options.name, vars=options.variables)
+        @async begin
+            attempts = 0
+            while true
+                try
+                    return dianaClient.Query(options.query, operationName=options.name, vars=options.variables)
+                catch err
+                    if attempts < 3
+                        @warn "[Test Client] WARN Client saw an exception. Retrying!" exception=(err, catch_backtrace())
+                        sleep(2)
+                        attempts += 1
+                    else
+                        rethrow()
+                    end
+                end
+            end
+        end
     end
     function mutate(options::MutationOptions)
         # NOTE, the query client library used is synchronous, locally converted to async for package consistency
-        @async dianaClient.Query(options.mutation, operationName=options.name, vars=options.variables)
+        @async begin
+            attempts = 0
+                while true
+                try
+                    return dianaClient.Query(options.mutation, operationName=options.name, vars=options.variables)
+                catch err
+                    if attempts < 3
+                        @warn "[Test Client] WARN Client saw an exception. Retrying!" exception=(err, catch_backtrace())
+                        sleep(2)
+                        attempts += 1
+                    else
+                        rethrow()
+                    end
+                end
+            end
+        end
     end
     return NavAbilityClient(query, mutate)
 end

--- a/src/navability/graphql/Session.jl
+++ b/src/navability/graphql/Session.jl
@@ -39,6 +39,7 @@ mutation sdk_export_session(
 }
 """
 
+# get the blobId given the blob upload eventId
 GQL_GET_EXPORT_SESSION_COMPLETE_EVENT_BY_ID = """
   query events_by_id(\$eventId:String) {
     events(where: {status:{state:Complete}, context:{eventId:\$eventId}}) {

--- a/src/navability/services/Session.jl
+++ b/src/navability/services/Session.jl
@@ -1,4 +1,15 @@
 
+function getExportSessionBlobId(client::NavAbilityClient, eventId::AbstractString)
+    response = client.query(QueryOptions(
+        "events_by_id",
+        GQL_GET_EXPORT_SESSION_COMPLETE_EVENT_BY_ID,
+        Dict("eventId" => eventId)
+    )) |> fetch
+    payload = JSON.parse(response.Data)
+    blobId = payload["data"]["events"][1]["data"]["blob"]["id"]
+    return blobId
+end
+
 function exportSessionEvent(
     client::NavAbilityClient,
     session::ExportSessionInput;
@@ -12,7 +23,7 @@ function exportSessionEvent(
       payload["options"] = options
   end
   response = client.mutate(MutationOptions(
-      "exportSession",
+      "sdk_export_session",
       MUTATION_EXPORT_SESSION,
       payload
   )) |> fetch

--- a/src/navability/services/Utils.jl
+++ b/src/navability/services/Utils.jl
@@ -88,15 +88,6 @@ function waitForCompletion2(
     end
 end
 
-function waitForCompletionExportSession(client::NavAbilityClient, eventId::AbstractString)
-    response = client.query(QueryOptions(
-        GQL_GET_EXPORT_SESSION_COMPLETE_EVENT_BY_ID,
-        Dict("eventId" => eventId)
-    )) |> fetch
-    payload = JSON.parse(response.Data)
-    blobId = payload["data"]["test"][1]["data"]["blob"]["id"]
-end
-
 # helper functions to construct for most likely user object
 function GraphVizApp(ct::Client; variableStartsWith=nothing)
     suffix = ""

--- a/test/integration/testExportSession.jl
+++ b/test/integration/testExportSession.jl
@@ -42,7 +42,6 @@ function runExportTests(client, context)
   @testset "test exportSession" begin
     @info "Running test exportSession"
 
-    @error "restore exportSession test"
-    # testExportSession(client, context; buildNewGraph=false)
+    testExportSession(client, context; buildNewGraph=false)
   end
 end

--- a/test/integration/testExportSession.jl
+++ b/test/integration/testExportSession.jl
@@ -34,7 +34,9 @@ function testExportSession(
                               )) |> fetch
 
   @info "waiting for export Session" eventId
-  NVA.waitForCompletionExportSession(client, eventId)
+  NVA.waitForCompletion2(client, eventId)
+  blobId = NVA.getExportSessionBlobId(client, eventId)
+  @info "Success: Here is the blobId you can use to download: $blobId"
 end
 
 


### PR DESCRIPTION
Current error something to do with SDK not sending or cloud not recognizing `exportSession` command:

```julia
nested task error: HTTP.Exceptions.StatusError(400, "POST", "/", HTTP.Messages.Response:
          """
          HTTP/1.1 400 Bad Request
          Date: Thu, 18 Aug 2022 04:10:21 GMT
          Content-Type: application/json; charset=utf-8
          Content-Length: 116
          Connection: keep-alive
          X-Powered-By: Express
          Access-Control-Allow-Origin: *
          ETag: W/"74-SmSrkEj0jSDKVUusv98NBdVhXKg"
          
          {"errors":[{"message":"Unknown operation named \"exportSession\".","extensions":{"code":"INTERNAL_SERVER_ERROR"}}]}
          """)
          Stacktrace:
            [1] (::HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}})(stream::HTTP.Streams.Stream{HTTP.Messages.Response, HTTP.ConnectionPool.Connection}; status_exception::Bool, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.ExceptionRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/ExceptionRequest.jl:16
            [2] (::HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}})(stream::HTTP.Streams.Stream{HTTP.Messages.Response, HTTP.ConnectionPool.Connection}; readtimeout::Int64, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.TimeoutRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/TimeoutRequest.jl:17
            [3] (::HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}})(req::HTTP.Messages.Request; proxy::Nothing, socket_type::Type, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.ConnectionRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/ConnectionRequest.jl:103
            [4] (::HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}})(req::HTTP.Messages.Request; canonicalize_headers::Bool, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.CanonicalizeRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/CanonicalizeRequest.jl:17
            [5] (::Base.var"#76#78"{Base.var"#76#77#79"{ExponentialBackOff, HTTP.RetryRequest.var"#3#6"{Int64, HTTP.Messages.Request, Base.RefValue{Int64}}, HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}})(args::HTTP.Messages.Request; kwargs::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ Base ./error.jl:294
            [6] (::HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}})(req::HTTP.Messages.Request; retry::Bool, retries::Int64, retry_non_idempotent::Bool, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.RetryRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/RetryRequest.jl:60
            [7] (::HTTP.CookieRequest.var"#1#5"{HTTP.CookieRequest.var"#1#2#6"{HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}}}})(req::HTTP.Messages.Request; cookies::Bool, cookiejar::HTTP.Cookies.CookieJar, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.CookieRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/CookieRequest.jl:42
            [8] (::HTTP.ContentTypeDetection.var"#1#3"{HTTP.ContentTypeDetection.var"#1#2#4"{HTTP.CookieRequest.var"#1#5"{HTTP.CookieRequest.var"#1#2#6"{HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}}}}}})(req::HTTP.Messages.Request; detect_content_type::Bool, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.ContentTypeDetection ~/.julia/packages/HTTP/4Xalq/src/clientlayers/ContentTypeRequest.jl:23
            [9] (::HTTP.BasicAuthRequest.var"#1#3"{HTTP.BasicAuthRequest.var"#1#2#4"{HTTP.ContentTypeDetection.var"#1#3"{HTTP.ContentTypeDetection.var"#1#2#4"{HTTP.CookieRequest.var"#1#5"{HTTP.CookieRequest.var"#1#2#6"{HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}}}}}}}})(req::HTTP.Messages.Request; basicauth::Bool, kw::Base.Pairs{Symbol, Union{Nothing, Integer}, Tuple{Symbol, Symbol, Symbol}, NamedTuple{(:iofunction, :decompress, :verbose), Tuple{Nothing, Bool, Int64}}})
              @ HTTP.BasicAuthRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/BasicAuthRequest.jl:22
           [10] (::HTTP.DefaultHeadersRequest.var"#1#3"{HTTP.DefaultHeadersRequest.var"#1#2#4"{HTTP.BasicAuthRequest.var"#1#3"{HTTP.BasicAuthRequest.var"#1#2#4"{HTTP.ContentTypeDetection.var"#1#3"{HTTP.ContentTypeDetection.var"#1#2#4"{HTTP.CookieRequest.var"#1#5"{HTTP.CookieRequest.var"#1#2#6"{HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}}}}}}}}}})(req::HTTP.Messages.Request; iofunction::Nothing, decompress::Bool, kw::Base.Pairs{Symbol, Int64, Tuple{Symbol}, NamedTuple{(:verbose,), Tuple{Int64}}})
              @ HTTP.DefaultHeadersRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/DefaultHeadersRequest.jl:47
           [11] (::HTTP.RedirectRequest.var"#1#4"{HTTP.RedirectRequest.var"#1#2#5"{HTTP.DefaultHeadersRequest.var"#1#3"{HTTP.DefaultHeadersRequest.var"#1#2#4"{HTTP.BasicAuthRequest.var"#1#3"{HTTP.BasicAuthRequest.var"#1#2#4"{HTTP.ContentTypeDetection.var"#1#3"{HTTP.ContentTypeDetection.var"#1#2#4"{HTTP.CookieRequest.var"#1#5"{HTTP.CookieRequest.var"#1#2#6"{HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}}}}}}}}}}}})(req::HTTP.Messages.Request; redirect::Bool, redirect_limit::Int64, redirect_method::Nothing, forwardheaders::Bool, response_stream::Nothing, kw::Base.Pairs{Symbol, Int64, Tuple{Symbol}, NamedTuple{(:verbose,), Tuple{Int64}}})
              @ HTTP.RedirectRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/RedirectRequest.jl:25
           [12] #1#2
              @ ~/.julia/packages/HTTP/4Xalq/src/clientlayers/DebugRequest.jl:22 [inlined]
           [13] (::HTTP.MessageRequest.var"#1#3"{HTTP.MessageRequest.var"#1#2#4"{HTTP.DebugRequest.var"#1#4"{HTTP.DebugRequest.var"#1#2#5"{HTTP.RedirectRequest.var"#1#4"{HTTP.RedirectRequest.var"#1#2#5"{HTTP.DefaultHeadersRequest.var"#1#3"{HTTP.DefaultHeadersRequest.var"#1#2#4"{HTTP.BasicAuthRequest.var"#1#3"{HTTP.BasicAuthRequest.var"#1#2#4"{HTTP.ContentTypeDetection.var"#1#3"{HTTP.ContentTypeDetection.var"#1#2#4"{HTTP.CookieRequest.var"#1#5"{HTTP.CookieRequest.var"#1#2#6"{HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}}}}}}}}}}}}}}}})(method::String, url::URIs.URI, headers::Vector{Pair{SubString{String}, SubString{String}}}, body::String; response_stream::Nothing, http_version::VersionNumber, kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
              @ HTTP.MessageRequest ~/.julia/packages/HTTP/4Xalq/src/clientlayers/MessageRequest.jl:17
           [14] #1
              @ ~/.julia/packages/HTTP/4Xalq/src/clientlayers/MessageRequest.jl:16 [inlined]
           [15] request(stack::HTTP.MessageRequest.var"#1#3"{HTTP.MessageRequest.var"#1#2#4"{HTTP.DebugRequest.var"#1#4"{HTTP.DebugRequest.var"#1#2#5"{HTTP.RedirectRequest.var"#1#4"{HTTP.RedirectRequest.var"#1#2#5"{HTTP.DefaultHeadersRequest.var"#1#3"{HTTP.DefaultHeadersRequest.var"#1#2#4"{HTTP.BasicAuthRequest.var"#1#3"{HTTP.BasicAuthRequest.var"#1#2#4"{HTTP.ContentTypeDetection.var"#1#3"{HTTP.ContentTypeDetection.var"#1#2#4"{HTTP.CookieRequest.var"#1#5"{HTTP.CookieRequest.var"#1#2#6"{HTTP.RetryRequest.var"#1#4"{HTTP.RetryRequest.var"#1#2#5"{HTTP.CanonicalizeRequest.var"#1#3"{HTTP.CanonicalizeRequest.var"#1#2#4"{HTTP.ConnectionRequest.var"#1#4"{HTTP.ConnectionRequest.var"#1#2#5"{HTTP.TimeoutRequest.var"#1#4"{HTTP.TimeoutRequest.var"#1#2#5"{HTTP.ExceptionRequest.var"#1#3"{HTTP.ExceptionRequest.var"#1#2#4"{typeof(HTTP.StreamRequest.streamlayer)}}}}}}}}}}}}}}}}}}}}}}}}, method::String, url::String, h::Vector{Pair{SubString{String}, SubString{String}}}, b::String, q::Nothing; headers::Vector{Pair{SubString{String}, SubString{String}}}, body::String, query::Nothing, kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
              @ HTTP ~/.julia/packages/HTTP/4Xalq/src/HTTP.jl:412
           [16] request(stack::Function, method::String, url::String, h::Vector{Pair{SubString{String}, SubString{String}}}, b::String, q::Nothing)
              @ HTTP ~/.julia/packages/HTTP/4Xalq/src/HTTP.jl:412
           [17] #request#16
              @ ~/.julia/packages/HTTP/4Xalq/src/HTTP.jl:272 [inlined]
           [18] request
              @ ~/.julia/packages/HTTP/4Xalq/src/HTTP.jl:272 [inlined]
           [19] #post#36
              @ ~/.julia/packages/HTTP/4Xalq/src/HTTP.jl:480 [inlined]
           [20] post
              @ ~/.julia/packages/HTTP/4Xalq/src/HTTP.jl:480 [inlined]
           [21] Queryclient(url::String, data::String; vars::Dict{String, Any}, auth::String, headers::Dict{Any, Any}, getlink::Bool, check::Bool, operationName::String)
              @ Diana ~/.julia/packages/Diana/5gAXI/src/client.jl:51
           [22] (::Diana.var"#Query#7"{Diana.var"#Query#3#8"})(data::String; vars::Dict{String, Any}, getlink::Bool, check::Bool, operationName::String)
              @ Diana ~/.julia/packages/Diana/5gAXI/src/client.jl:92
           [23] (::NavAbilitySDK.var"#3#7"{MutationOptions, Diana.Client})()
              @ NavAbilitySDK ./task.jl:429
[ Info: [Fixture] Adding variables, waiting for completion
[ Info: [Fixture] Adding factors, waiting for completion
Test Summary:               | Pass  Error  Total
nva-sdk-integration-testset |   29      1     30
  Testing Variables         |   17            17
  run initVariable tests    |    1             1
  factor-testset            |    9             9
  solve-testset             |    2             2
  appviz-testset            |              No tests
  test exportSession        |           1      1
ERROR: LoadError: Some tests did not pass: 29 passed, 0 failed, 1 errored, 0 broken.
in expression starting at /home/dehann/.julia/dev/NavAbilitySDK/test/integration/runtests.jl:18
in expression starting at /home/dehann/.julia/dev/NavAbilitySDK/test/runtests.jl:2
```